### PR TITLE
[WIP] Ability to handle sequence along with its quality information and name

### DIFF
--- a/src/demux.jl
+++ b/src/demux.jl
@@ -336,7 +336,7 @@ function matchPrimer(qseq::Tuple{Any,Any,Any},forwardPrimers,revPrimers,forwardN
 end
 
 function deMux(qseqs::Tuple{Array,Array,Array},forwardPrimers,reversePrimers, forwardNames,reverseNames)
-    matched = [matchPrimer(qseq,forwardPrimers,reversePrimers,forwardNames,reverseNames) for qseq in zip(qseqs[1], qseqs[2], qseqs[3])];
+    matched = [matchPrimer(qseq,forwardPrimers,reversePrimers,forwardNames,reverseNames) for qseq in zip(qseqs...)];
     return [[i[2],i[3], i[5], i[4]] for i in matched]
 end
 

--- a/src/demux.jl
+++ b/src/demux.jl
@@ -301,7 +301,7 @@ function matchPrimer(qseq::Tuple{Any,Any,Any},forwardPrimers,revPrimers,forwardN
     fwd_qseq = qseq;
     fwd_seq = fwd_qseq[1];
     rev_seq = reverse_complement(fwd_seq);
-    rev_qsec = (rev_seq, fwd_qseq[2], fwd_qseq[3]); # The second and third element remain the same
+    rev_qseq = (rev_seq, fwd_qseq[2], fwd_qseq[3]); # The second and third element remain the same
     fwdSeqFwdPrim = [IUPAC_nuc_edit_dist(fwd_seq[1:length(prim)],prim) for prim in forwardPrimers];
     revSeqFwdPrim = [IUPAC_nuc_edit_dist(rev_seq[1:length(prim)],prim) for prim in forwardPrimers];
     fwdSeqRevPrim = [IUPAC_nuc_edit_dist(fwd_seq[1:length(prim)],prim) for prim in revPrimers];

--- a/src/demux.jl
+++ b/src/demux.jl
@@ -336,7 +336,7 @@ function matchPrimer(qseq::Tuple{Any,Any,Any},forwardPrimers,revPrimers,forwardN
 end
 
 function deMux(qseqs::Tuple{Array,Array,Array},forwardPrimers,reversePrimers, forwardNames,reverseNames)
-    matched = [matchPrimer(qseq,forwardPrimers,reversePrimers,forwardNames,reverseNames) for qseq in zip(qseqs)];
+    matched = [matchPrimer(qseq,forwardPrimers,reversePrimers,forwardNames,reverseNames) for qseq in zip(qseqs[1], qseqs[2], qseqs[3])];
     return [[i[2],i[3], i[5], i[4]] for i in matched]
 end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -138,3 +138,20 @@ function write_fastq(filename, seqs, phreds::Vector{Vector{Phred}};
     end
     close(stream)
 end
+
+function simple_write_fastq(filename, q_seqs, DNASeqType=false)
+    seqs, phreds, names = q_seqs
+    if !DNASeqType
+        seqs = [DNASequence(s) for s in seqs]
+    end
+    stream = open(FASTQ.Writer, filename)
+    i = 0
+    if length(names) != length(seqs)
+        names = [string("seq_", i) for i in 1:length(seqs)]
+    end
+    for (s, q, n) in zip(seqs, phreds, names)
+        i += 1
+        write(stream, FASTQ.Record(n, s, q))
+    end
+    close(stream)
+end

--- a/src/io.jl
+++ b/src/io.jl
@@ -139,24 +139,12 @@ function write_fastq(filename, seqs, phreds::Vector{Vector{Phred}};
     close(stream)
 end
 
-function simple_write_fastq(filename, q_seqs, DNASeqType=false)
-    seqs, phreds, names = q_seqs
-	if typeof(seqs) != Tuple{Array,Array,Array}
-		seqs = [seqs];
-		phreds = [phreds];
-		names = [names];
-	end
-    if !DNASeqType
-        seqs = [DNASequence(s) for s in seqs]
+function append_fastq(filename::String, q_seq::Tuple{String,Array{Int8},String}, DNASeqType=false)
+    seq, phred, name = q_seq
+	if !DNASeqType
+        seq = DNASequence(seq)
     end
     stream = FASTQ.Writer(open(filename, "a"))
-    i = 0
-    if length(names) != length(seqs)
-        names = [string("seq_", i) for i in 1:length(seqs)]
-    end
-    for (s, q, n) in zip(seqs, phreds, names)
-        i += 1
-        write(stream, FASTQ.Record(n, s, q))
-    end
+	write(stream, FASTQ.Record(name, seq, phred))
     close(stream)
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -149,7 +149,7 @@ function simple_write_fastq(filename, q_seqs, DNASeqType=false)
     if !DNASeqType
         seqs = [DNASequence(s) for s in seqs]
     end
-    stream = open(FASTQ.Writer, filename)
+    stream = FASTQ.Writer(open(filename, "a"))
     i = 0
     if length(names) != length(seqs)
         names = [string("seq_", i) for i in 1:length(seqs)]

--- a/src/io.jl
+++ b/src/io.jl
@@ -141,6 +141,11 @@ end
 
 function simple_write_fastq(filename, q_seqs, DNASeqType=false)
     seqs, phreds, names = q_seqs
+	if typeof(seqs) != Tuple{Array,Array,Array}
+		seqs = [seqs];
+		phreds = [phreds];
+		names = [names];
+	end
     if !DNASeqType
         seqs = [DNASequence(s) for s in seqs]
     end


### PR DESCRIPTION
This is not ready for merging at all and I suspect might break some other components.

I just found it useful to be able to handle each sequence as a unit (name, sequence and quality). This way each sequence can be fed to a function that streams to a fastq file based on its characteristics.

An example script which would use this library with the changes made in this PR:


```
import NextGenSeqUtils.deMux
import NextGenSeqUtils.read_fastq
import NextGenSeqUtils.append_fastq

# Example config:
config = {
    "pool1": {
        "fastq_path": ".../pool1.fastq",
        "fwd_barcode_codes": ["1", "2"]
        "fwd_barcode_seqs": ["ACGT...", "AAAA..."]
        "rev_barcode_codes": ["A", "A"],
        "rev_barcode_seqs": ["CTGTC...", "CTGTC..."]
        "sample_name_mappings": {
            "1_A": "PART1_1100_010wpi_Env_gp160_PID_TY",
            "2_A": "PART1_1120_012wpi_Env_gp160_PID_TY"
        }
    }
    "pool2": {...},
    "pool3": {...}
}


for (pool, sample_data) in config
    q_seqs = read_fastq(sample_data["fastq_path"]);
    demuxed = deMux(q_seqs, sample_data["fwd_barcode_seqs"], sample_data["rev_barcode_seqs"],
                    sample_data["fwd_barcode_codes"], sample_data["rev_barcode_codes"]);
    for barcode_code_pair, q_seq, _, match_error  in demuxed
        sample_name = pool * "_" * sample_data["sample_name_mappings"][barcode_code_pair]
        # Enter some logic here to filter by error score (match_error)
        append_fastq(sample_name * ".fastq", q_seq);
    end
end
```

Interested to know if there is a better approach. I am pretty new to Julia myself.